### PR TITLE
Add formatter for exceptions in plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ return [
 ];
 ```
 
-Last but not least, copy over the dist configuration files located the `config/` directory to
-your application's autoload directory.
-
-
 ## Usage
 
 This module has a predefined `ErrorLogger` logging channel configured. This channel is used to write PHP notices, 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -10,6 +10,8 @@
 namespace PolderKnowledge\LogModule;
 
 use Monolog\Logger;
+use PolderKnowledge\LogModule\Formatter\HumanReadableExceptionFormatter;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'controller_plugins' => [
@@ -34,6 +36,9 @@ return [
                     'error-server-params',
                 ],
             ],
+        ],
+        'formatters' => [
+
         ],
         'handlers' => [
         ],
@@ -61,6 +66,7 @@ return [
         ],
         'factories' => [
             Listener\MvcEventError::class => Listener\Factory\MvcEventErrorFactory::class,
+            HumanReadableExceptionFormatter::class => InvokableFactory::class,
         ],
     ],
     'view_helpers' => [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- convertDeprecationsToExceptions="false" to test zf2 factories -->
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
@@ -7,6 +8,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="false"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>

--- a/src/Formatter/ExceptionPrinter.php
+++ b/src/Formatter/ExceptionPrinter.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace PolderKnowledge\LogModule\Formatter;
+
+class ExceptionPrinter
+{
+    public static function linesFromException(\Throwable $exception, bool $nested = false): array
+    {
+        $lines = [];
+        $lines[] = self::printFirstLineFromException($exception, $nested);
+
+        foreach ($exception->getTrace() as $traceLine) {
+            $lines[] = self::formatTraceLine($traceLine);
+        }
+
+        if ($exception->getPrevious()) {
+            $previousLines = self::linesFromException($exception->getPrevious(), true);
+
+            // recursion makes sure deeper nesting has longer prefixes
+            foreach ($previousLines as $previousLine) {
+                $lines[] = '  ' . $previousLine;
+            }
+        }
+
+        return $lines;
+    }
+
+    public static function printFirstLineFromException(\Throwable $exception, bool $nested): string
+    {
+        return sprintf('[%s] %s: %s in %s:%s', ...[
+            // only the root exception has a timestamp
+            $nested ? 'Previous Exception' : date('r'),
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        ]);
+    }
+
+    /**
+     * Transform an element of the array Exception::getTrace
+     * to a string of a single line
+     *
+     * @param mixed[] $trace element of Exception::getTrace
+     * @return string of a single line
+     */
+    public static function formatTraceLine(array $trace): string
+    {
+        $output = '';
+
+        // only display file if we're not in the context of a class
+        // to save space for the sake for readability of the stack trace
+        if (isset($trace['file']) && !isset($trace['class'])) {
+            $output .= $trace['file'];
+
+            if (isset($trace['line'])) {
+                $output .= '(' . $trace['line'] . ')';
+            }
+
+            if (!isset($trace['function'])) {
+                return $output;
+            }
+        }
+
+        $output .= $trace['class'] ?? '';
+        $output .= $trace['type'] ?? '';
+        $output .= $trace['function'] ?? '';
+
+        if (isset($trace['function'])) {
+            $arguments = self::formatArguments($trace['args'] ?? []);
+            $output .= '(' . $arguments . ')';
+        }
+
+        // print line number now if we skipped it
+        if (isset($trace['class']) && isset($trace['line'])) {
+            $output .= ':' . $trace['line'];
+        }
+
+        return $output;
+    }
+
+    /**
+     * Convert function arguments of any type to a short readable string
+     *
+     * @param mixed[] $arguments
+     * @return string a summary of the list of arguments
+     */
+    public static function formatArguments(array $arguments): string
+    {
+        return implode(', ', array_map([__CLASS__, 'formatArgument'], $arguments));
+    }
+
+    /**
+     * Summarize a variable
+     *
+     * @param mixed $argument anything at all
+     * @return string a summary of the argument
+     */
+    public static function formatArgument($argument): string
+    {
+        if (is_object($argument)) {
+            return get_class($argument);
+        }
+
+        if (is_int($argument) || is_float($argument)) {
+            return $argument;
+        }
+
+        if (is_string($argument)) {
+            return self::truncateString($argument);
+        }
+
+        if ($argument === false) {
+            return 'false';
+        }
+
+        if ($argument === true) {
+            return 'true';
+        }
+
+        if (is_array($argument)) {
+            return 'array(' . count($argument) . ')';
+        }
+
+        // resource or null
+        return gettype($argument);
+    }
+
+    public static function truncateString(string $argument): string
+    {
+        if (strlen($argument) < 80) {
+            $truncated = $argument;
+        } else {
+            $truncated = substr($argument, 0, 30) . '...' . substr($argument, -30, 30);
+        }
+
+        return "'$truncated'";
+    }
+}

--- a/src/Formatter/HumanReadableExceptionFormatter.php
+++ b/src/Formatter/HumanReadableExceptionFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PolderKnowledge\LogModule\Formatter;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\NormalizerFormatter;
+
+/**
+ * Format an Exception in a similar way PHP does by default when an exception bubbles to the top
+ */
+class HumanReadableExceptionFormatter extends NormalizerFormatter implements FormatterInterface
+{
+    public function format(array $record): string
+    {
+        $exception = $record['context']['exception'] ?? null;
+        if ($exception) {
+            return $this->printFromException($exception);
+        } else {
+            return $this->printWithoutException($record);
+        }
+    }
+
+    protected function printWithoutException(array $record): string
+    {
+        return sprintf('[%s] %s: %s', ...[
+            date('r'),
+            $record['level_name'],
+            $record['message']
+        ]);
+    }
+    
+    protected function printFromException(\Throwable $exception)
+    {
+        return implode("\n", ExceptionPrinter::linesFromException($exception)) . "\n"
+            . "---------------------------------------\n";
+    }
+}

--- a/src/Listener/MvcEventError.php
+++ b/src/Listener/MvcEventError.php
@@ -21,7 +21,7 @@ final class MvcEventError
      * @var LoggerInterface
      */
     protected $logger;
-    
+
     /**
      * @param LoggerInterface $logger
      */
@@ -39,7 +39,7 @@ final class MvcEventError
     {
         return $this->logger;
     }
-    
+
     /**
      * Should be called when an MvcEvent is fired.
      *
@@ -53,27 +53,7 @@ final class MvcEventError
         }
 
         $exception = $event->getParam('exception');
-        $logMessages = [];
 
-        do {
-            $extra = array(
-                'file' => $exception->getFile(),
-                'line' => $exception->getLine(),
-                'trace' => $exception->getTrace(),
-            );
-            if (isset($exception->xdebug_message)) {
-                $extra['xdebug'] = $exception->xdebug_message;
-            }
-
-            $logMessages[] = array(
-                'message' => $exception->getMessage(),
-                'extra' => $extra,
-            );
-            $exception = $exception->getPrevious();
-        } while ($exception);
-
-        foreach (array_reverse($logMessages) as $logMessage) {
-            $this->logger->error($logMessage['message'], $logMessage['extra']);
-        }
+        $this->logger->error($exception->getMessage(), ['exception' => $exception]);
     }
 }

--- a/tests/Formatter/FormatArgumentTest.php
+++ b/tests/Formatter/FormatArgumentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PolderKnowledge\LogModule\Formatter;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Throwable or Exception is not mockable due to its final methods
+ * So we cannot unittest everything
+ */
+class FormatArgumentTest extends TestCase
+{
+    /**
+     * @dataProvider formatProvider
+     */
+    public function testFormatArgument($argument, $expected)
+    {
+        self::assertEquals($expected, ExceptionPrinter::formatArgument($argument));
+    }
+
+    public function formatProvider()
+    {
+        return [
+            [true, 'true'],
+            [false, 'false'],
+            [[0, 0, 0], 'array(3)'],
+            [new \stdClass, 'stdClass'],
+            [fopen(__FILE__, 'r'), 'resource'],
+            ['mystring', "'mystring'"],
+            [
+                'If there is a long string in the arguments, it should be truncated,'
+                    . ' so that the logging stays concise',
+                "'If there is a long string in t...that the logging stays concise'",
+            ],
+            [null, 'NULL'],
+        ];
+    }
+}

--- a/tests/Formatter/FormatTraceTest.php
+++ b/tests/Formatter/FormatTraceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PolderKnowledge\LogModule\Formatter;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Throwable or Exception is not mockable due to its final methods
+ * So we cannot unittest everything
+ */
+class FormatTraceTest extends TestCase
+{
+    public function testFormatStackTrace()
+    {
+        $trace = $this->getTrace();
+
+        self::assertEquals(
+            "MyClass->MyMethod(false, 'mystring', array(3), stdClass, NULL):42",
+            ExceptionPrinter::formatTraceLine($trace[0])
+        );
+
+        self::assertEquals(
+            'index.php(144)',
+            ExceptionPrinter::formatTraceLine($trace[1])
+        );
+
+    }
+
+    private function getTrace()
+    {
+        return [
+            [
+                'file' => 'MyClass.php',
+                'line' => 42,
+                'class' => 'MyClass',
+                'type' => '->',
+                'function' => 'MyMethod',
+                'args' => [
+                    false,
+                    'mystring',
+                    [0, 0, 0],
+                    new \stdClass,
+                    null,
+                ],
+            ], [
+                'file' => 'index.php',
+                'line' => '144',
+                'class' => null,
+                'type' => null,
+                'function' => null,
+                'args' => null,
+            ]
+        ];
+    }
+}

--- a/tests/Listener/MvcEventErrorTest.php
+++ b/tests/Listener/MvcEventErrorTest.php
@@ -38,58 +38,12 @@ final class MvcEventErrorTest extends TestCase
         // Assert
         static::assertSame($this->loggerMock, $result);
     }
-    
-    /**
-     * @dataProvider expectedParamsProvider
-     */
-    public function testLoggerIsCalledWithExpectedParams($exception, $extra)
+
+    public function testLoggerIsCalledWithExpectedParams()
     {
         // Arrange
-        $this->loggerMock->expects($this->once())->method('error')->with('Exception', $extra);
-
-        $eventMock = $this->createMock(MvcEvent::class);
-        $eventMock->expects($this->atLeastOnce())->method('getError')->willReturn('error-exception');
-        $eventMock->expects($this->atLeastOnce())->method('getParam')->with('exception')->willReturn($exception);
-
-        // Act
-        $this->mvcEventError->__invoke($eventMock);
-
-        // Assert
-        // ...
-    }
-    
-    public function expectedParamsProvider()
-    {
-        $exception = new Exception('Exception');
-        $exceptionWithXDebug = new Exception('Exception');
-        $exceptionWithXDebug->xdebug_message = 'xdebug_message';
-        
-        $extra = [
-            'file' => $exception->getFile(),
-            'line' => $exception->getLine(),
-            'trace' => $exception->getTrace(),
-        ];
-        
-        $extraWithXDebug = [
-            'file' => $exceptionWithXDebug->getFile(),
-            'line' => $exceptionWithXDebug->getLine(),
-            'trace' => $exceptionWithXDebug->getTrace(),
-            'xdebug' => 'xdebug_message',
-        ];
-        
-        return [
-            [$exception, $extra],
-            [$exceptionWithXDebug, $extraWithXDebug]
-        ];
-    }
-    
-    public function testLoggerIsCalledForPreviousExceptions()
-    {
-        // Arrange
-        $previousException = new Exception('PreviousException');
-        $exception = new Exception('Exception', null, $previousException);
-
-        $this->loggerMock->expects($this->exactly(2))->method('error');
+        $exception = new Exception('Exception message');
+        $this->loggerMock->expects($this->once())->method('error')->with('Exception message', ['exception' => $exception]);
 
         $eventMock = $this->createMock(MvcEvent::class);
         $eventMock->expects($this->atLeastOnce())->method('getError')->willReturn('error-exception');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Describe your changes in detail.

_Added a formatter for exceptions to an easier-to-read format_
_Removed formatting logic from the zend mvc listener and instead pass the exception to monolog which does a better job. This is a breaking change_

## Motivation and context

Why is this change required? What problem does it solve? _I want to read my logs_

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?

Please describe in detail how you tested your changes. _Test includes so far as possible. The stacktraces in an Exception/Throwable can't be mocked so this makes an end-to-end test impossible._

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

_This is the new format:_

```
---------------------------------------
[Wed, 03 Jan 2018 19:57:35 +0100] RuntimeException: msgn in /var/www/module/Shop/src/Controller/Order.php:25
TotalLubricants\Shop\Controller\Order->orderAction():78
Zend\Mvc\Controller\AbstractActionController->onDispatch(Object(Zend\Mvc\MvcEvent)):322
Zend\EventManager\EventManager->triggerListeners(Object(Zend\Mvc\MvcEvent), Object(Closure)):179
Zend\EventManager\EventManager->triggerEventUntil(Object(Closure), Object(Zend\Mvc\MvcEvent)):106
Zend\Mvc\Controller\AbstractController->dispatch(Object(Zend\Http\PhpEnvironment\Request), Object(Zend\Http\PhpEnvironment\Response)):138
Zend\Mvc\DispatchListener->onDispatch(Object(Zend\Mvc\MvcEvent)):322
Zend\EventManager\EventManager->triggerListeners(Object(Zend\Mvc\MvcEvent), Object(Closure)):179
Zend\EventManager\EventManager->triggerEventUntil(Object(Closure), Object(Zend\Mvc\MvcEvent)):332
Zend\Mvc\Application->run():37
……[Previous Exception] InvalidArgumentException: asdfasdf in /var/www/module/Shop/src/Controller/Order.php:23
……TotalLubricants\Shop\Controller\Order->orderAction():78
……Zend\Mvc\Controller\AbstractActionController->onDispatch(Object(Zend\Mvc\MvcEvent)):322
……Zend\EventManager\EventManager->triggerListeners(Object(Zend\Mvc\MvcEvent), Object(Closure)):179
……Zend\EventManager\EventManager->triggerEventUntil(Object(Closure), Object(Zend\Mvc\MvcEvent)):106
……Zend\Mvc\Controller\AbstractController->dispatch(Object(Zend\Http\PhpEnvironment\Request), Object(Zend\Http\PhpEnvironment\Response)):138
……Zend\Mvc\DispatchListener->onDispatch(Object(Zend\Mvc\MvcEvent)):322
……Zend\EventManager\EventManager->triggerListeners(Object(Zend\Mvc\MvcEvent), Object(Closure)):179
……Zend\EventManager\EventManager->triggerEventUntil(Object(Closure), Object(Zend\Mvc\MvcEvent)):332
……Zend\Mvc\Application->run():37
---------------------------------------
```
_A possible improvement is removing duplicate lines in the previous exception_

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

  
  