### PR TITLE
Added a new line

### DIFF
--- a/src/Formatter/HumanReadableExceptionFormatter.php
+++ b/src/Formatter/HumanReadableExceptionFormatter.php
@@ -22,7 +22,7 @@ class HumanReadableExceptionFormatter extends NormalizerFormatter implements For
 
     protected function printWithoutException(array $record): string
     {
-        return sprintf('[%s] %s: %s', ...[
+        return sprintf("[%s] %s: %s\n", ...[
             date('r'),
             $record['level_name'],
             $record['message']


### PR DESCRIPTION
The missing new line caused all the messages to be placed after each other making the file unreadable. This is the case when this formatter is used for error logging for example.
